### PR TITLE
Capped oplog and changes stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 ### Feauters:
 1. Oplog simulation
-2. Changes stream server
+2. Change stream server
 
 ### Using: 
 ```
 fdbdoc -l 127.0.0.1:27016 -nl 127.0.0.1:8081
 ```
-1. "nl" - is address for changes stream server
+1. "nl" - is address for change stream server
 
-### Changes stream server
+### Change stream server
 Provides changes to port for listeners which are connected on port over tcp.
 
-Message fromat is:
-1. 8 byte for body size
+Message format is:
+1. 8 bytes for body size (LittleEndian Unit64)
 2. One byte delimiter
 3. Message body (bson object from local.oplog.rs in binary)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
+# Fork description
+
+### Feauters:
+1. Oplog simulation
+2. Changes stream server
+
+### Using: 
+```
+fdbdoc -l 127.0.0.1:27016 -nl 127.0.0.1:8081
+```
+1. "nl" - is address for changes stream server
+
+### Changes stream server
+Provides changes to port for listeners which are connected on port over tcp.
+
+Message fromat is:
+1. 8 byte for body size
+2. One byte delimiter
+3. Message body (bson object from local.oplog.rs in binary)
+
+### Recomendations:
+1. When local.oplog.rs will be created by doc layer, it's good to add index on "ts" field for best performance.
+
+### Known limitations:
+1. Writes logs only for "i", "u", "d" operations (no drops and other operations)
+2. Oplog structure has one difference from mongodb, that's exclusion "$" sign from field names (because doc layer has some limitations by it)
+3. "Capped" collection is simple deletion documents by time (only last 2 days are stored)
+4. Performance is decreased by increased transactions number because oplog (~1.8-2x times)
+
 # FoundationDB Document Layer
 
 The FoundationDB Document Layer is a stateless microserver that exposes a document-oriented database API. The Document Layer speaks the MongoDB® wire protocol, allowing the use of the MongoDB® API via existing MongoDB® client bindings. All persistent data are stored in the FoundationDB Key-Value Store.

--- a/docker/Dockerfile.Runtime
+++ b/docker/Dockerfile.Runtime
@@ -1,0 +1,9 @@
+FROM ubuntu:19.04
+
+COPY ./build-doc/bin /app
+COPY ./build/fdb.cluster /app/fdb.cluster
+
+ADD https://www.foundationdb.org/downloads/6.1.12/ubuntu/installers/foundationdb-clients_6.1.12-1_amd64.deb /tmp/fdb.deb
+RUN dpkg -i /tmp/fdb.deb
+
+ENTRYPOINT /bin/bash -c "/app/fdbdoc -C /app/fdb.cluster -V -l 0.0.0.0:27016 -nl 0.0.0.0:8081"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(fdbdoc
         MetadataManager.h
         Oplogger.h
         Oplogger.cpp
+        OplogMonitor.h
         QLContext.h
         QLExpression.h
         QLOperations.h
@@ -37,6 +38,7 @@ set(ACTOR_FILES
         ExtStructs.actor.cpp
         ExtUtil.actor.cpp
         MetadataManager.actor.cpp
+        OplogMonitor.actor.cpp
         QLContext.actor.cpp
         QLExpression.actor.cpp
         QLPlan.actor.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,8 @@ add_executable(fdbdoc
         Knobs.cpp
         Knobs.h
         MetadataManager.h
+        Oplogger.h
+        Oplogger.cpp
         QLContext.h
         QLExpression.h
         QLOperations.h

--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -37,11 +37,14 @@ const std::string INDICES_KEY = "indices";
 const std::string SYSTEM_INDEXES = "system.indexes";
 const std::string SYSTEM_NAMESPACES = "system.namespaces";
 
-const std::string LOCAL_OPLOG_RS = "local.oplog.rs";
+const std::string OPLOG_DB = "local";
+const std::string OPLOG_COL = "oplog.rs";
 
 const std::string OP_UPDATE = "u";
 const std::string OP_INSERT = "i";
 const std::string OP_DELETE = "d";
+
+const std::string DESCRIBE_DELETE_DOC = "delete document";
 
 const char* OP_FIELD_TS = "ts";
 const char* OP_FIELD_H = "h";

--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -37,6 +37,20 @@ const std::string INDICES_KEY = "indices";
 const std::string SYSTEM_INDEXES = "system.indexes";
 const std::string SYSTEM_NAMESPACES = "system.namespaces";
 
+const std::string LOCAL_OPLOG_RS = "local.oplog.rs";
+
+const std::string OP_UPDATE = "u";
+const std::string OP_INSERT = "i";
+const std::string OP_DELETE = "d";
+
+const char* OP_FIELD_TS = "ts";
+const char* OP_FIELD_H = "h";
+const char* OP_FIELD_V = "v";
+const char* OP_FIELD_OP = "op";
+const char* OP_FIELD_NS = "ns";
+const char* OP_FIELD_O2 = "o2";
+const char* OP_FIELD_O = "ns";
+
 const char* ID_FIELD = "_id";
 const char* KEY_FIELD = "key";
 const char* BUILD_ID_FIELD = "build id";

--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -37,6 +37,9 @@ const std::string INDICES_KEY = "indices";
 const std::string SYSTEM_INDEXES = "system.indexes";
 const std::string SYSTEM_NAMESPACES = "system.namespaces";
 
+const double OPLOG_EXPIRATION_TIME = 172800000; // delete oplog 2 days ago
+const double OPLOG_CLEAN_INTERVAL = 600; // clean every 10 minutes
+
 const std::string OPLOG_DB = "local";
 const std::string OPLOG_COL = "oplog.rs";
 

--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -52,7 +52,7 @@ const char* OP_FIELD_V = "v";
 const char* OP_FIELD_OP = "op";
 const char* OP_FIELD_NS = "ns";
 const char* OP_FIELD_O2 = "o2";
-const char* OP_FIELD_O = "ns";
+const char* OP_FIELD_O = "o";
 
 const char* ID_FIELD = "_id";
 const char* KEY_FIELD = "key";

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -46,6 +46,23 @@ extern const std::string INDICES_KEY;
 extern const std::string SYSTEM_INDEXES;
 extern const std::string SYSTEM_NAMESPACES;
 
+// Oplog collection
+extern const std::string LOCAL_OPLOG_RS;
+
+// Oplog operations
+extern const std::string OP_UPDATE;
+extern const std::string OP_INSERT;
+extern const std::string OP_DELETE;
+
+// Oplog Field name comstants
+extern const char* OP_FIELD_TS;
+extern const char* OP_FIELD_H;
+extern const char* OP_FIELD_V;
+extern const char* OP_FIELD_OP;
+extern const char* OP_FIELD_NS;
+extern const char* OP_FIELD_O2;
+extern const char* OP_FIELD_O;
+
 // BSON Field name constants
 extern const char* ID_FIELD;
 extern const char* KEY_FIELD;

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -46,6 +46,12 @@ extern const std::string INDICES_KEY;
 extern const std::string SYSTEM_INDEXES;
 extern const std::string SYSTEM_NAMESPACES;
 
+// Oplog expiration time in mills
+extern const double OPLOG_EXPIRATION_TIME;
+
+// Clean loop delay in mills
+extern const double OPLOG_CLEAN_INTERVAL;
+
 // Oplog namespace info
 extern const std::string OPLOG_DB;
 extern const std::string OPLOG_COL;

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -46,13 +46,17 @@ extern const std::string INDICES_KEY;
 extern const std::string SYSTEM_INDEXES;
 extern const std::string SYSTEM_NAMESPACES;
 
-// Oplog collection
-extern const std::string LOCAL_OPLOG_RS;
+// Oplog namespace info
+extern const std::string OPLOG_DB;
+extern const std::string OPLOG_COL;
 
 // Oplog operations
 extern const std::string OP_UPDATE;
 extern const std::string OP_INSERT;
 extern const std::string OP_DELETE;
+
+// Delete operation description
+extern const std::string DESCRIBE_DELETE_DOC;
 
 // Oplog Field name constants
 extern const char* OP_FIELD_TS;

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -54,7 +54,7 @@ extern const std::string OP_UPDATE;
 extern const std::string OP_INSERT;
 extern const std::string OP_DELETE;
 
-// Oplog Field name comstants
+// Oplog Field name constants
 extern const char* OP_FIELD_TS;
 extern const char* OP_FIELD_H;
 extern const char* OP_FIELD_V;

--- a/src/Cursor.actor.cpp
+++ b/src/Cursor.actor.cpp
@@ -34,7 +34,7 @@ int32_t Cursor::prune(std::map<int64_t, Reference<Cursor>>& cursors, bool pruneA
 
 	try {
 		for (auto it = cursors.begin(); it != cursors.end();) {
-			if (it->second && (pruneAll || now >= it->second->expiry)) {				
+			if (it->second && (pruneAll || now >= it->second->expiry)) {
 				to_be_pruned.push_back(it->second);
 			}
 			++it;

--- a/src/Cursor.h
+++ b/src/Cursor.h
@@ -33,6 +33,7 @@ struct Cursor : ReferenceCounted<Cursor>, NonCopyable {
 	int32_t returned;
 	std::map<int64_t, Reference<Cursor>>* siblings;
 	time_t expiry;
+	static std::map<int64_t, Reference<Cursor>> allCursors;
 
 	Cursor(FutureStream<Reference<ScanReturnedContext>> docs, Reference<PlanCheckpoint> checkpoint)
 	    : docs(docs), checkpoint(checkpoint), returned(0) {
@@ -47,6 +48,7 @@ struct Cursor : ReferenceCounted<Cursor>, NonCopyable {
 
 	static void pluck(Reference<Cursor> cursor);
 	static Reference<Cursor> add(std::map<int64_t, Reference<Cursor>>& siblings, Reference<Cursor> cursor);
+	static Reference<Cursor> get(int64_t id);
 };
 
 #endif /*** _CURSOR_H_ */

--- a/src/DocLayer.actor.cpp
+++ b/src/DocLayer.actor.cpp
@@ -193,7 +193,7 @@ ACTOR Future<Void> housekeeping(Reference<ExtConnection> ec) {
 		// through this connection. Prune all the cursors before cancelling
 		// this actor.
 		if (e.code() == error_code_actor_cancelled)
-			Cursor::prune(ec->cursors, true);
+			Cursor::prune(ec->cursors, true);					
 		throw;
 	}
 }

--- a/src/DocLayer.actor.cpp
+++ b/src/DocLayer.actor.cpp
@@ -238,7 +238,7 @@ ACTOR void extServer(Reference<DocumentLayer> docLayer, NetworkAddress addr, Ref
 
 		loop choose {
 			when(Reference<IConnection> conn = wait(listener->accept())) {
-				Reference<BufferedConnection> bc(new BufferedConnection(conn));						
+				Reference<BufferedConnection> bc(new BufferedConnection(conn));				
 				connections.add(extServerConnection(docLayer, bc, nextConnectionId, watcher));
 				nextConnectionId++;
 			}
@@ -544,7 +544,7 @@ ACTOR void setup(NetworkAddress na,
 		}
 		
 		
-		Reference<ExtChangeWatcher> watcher = ref(new ExtChangeWatcher(docLayer, changeStream));
+		state Reference<ExtChangeWatcher> watcher = Reference<ExtChangeWatcher>(new ExtChangeWatcher(docLayer, changeStream));
 		watcher->watch();
 
 		statusUpdateActor(FDB_DOC_VT_PACKAGE_NAME, na.ip.toString(), na.port, docLayer, timer() * 1000);

--- a/src/ExtCmd.actor.cpp
+++ b/src/ExtCmd.actor.cpp
@@ -592,7 +592,7 @@ ACTOR static Future<Reference<ExtMsgReply>> doFindAndModify(Reference<ExtConnect
 
 		state Reference<Plan> plan = planQuery(ucx, selector);
 		plan = ref(new FindAndModifyPlan(plan, updater, upserter, projection, ordering, isnew, ucx,
-		                                 ref(new DocInserter(ec->getWatcher())), ec->docLayer->database, ec->mm));
+		                                 ref(new DocInserter(ec->watcher)), ec->docLayer->database, ec->mm));
 
 		state std::pair<int64_t, Reference<ScanReturnedContext>> pair =
 		    wait(executeUntilCompletionAndReturnLastTransactionally(plan, tr));

--- a/src/ExtCmd.actor.cpp
+++ b/src/ExtCmd.actor.cpp
@@ -592,7 +592,7 @@ ACTOR static Future<Reference<ExtMsgReply>> doFindAndModify(Reference<ExtConnect
 
 		state Reference<Plan> plan = planQuery(ucx, selector);
 		plan = ref(new FindAndModifyPlan(plan, updater, upserter, projection, ordering, isnew, ucx,
-		                                 ref(new DocInserter()), ec->docLayer->database, ec->mm));
+		                                 ref(new DocInserter(ec->getChangeStream())), ec->docLayer->database, ec->mm));
 
 		state std::pair<int64_t, Reference<ScanReturnedContext>> pair =
 		    wait(executeUntilCompletionAndReturnLastTransactionally(plan, tr));

--- a/src/ExtCmd.actor.cpp
+++ b/src/ExtCmd.actor.cpp
@@ -592,7 +592,7 @@ ACTOR static Future<Reference<ExtMsgReply>> doFindAndModify(Reference<ExtConnect
 
 		state Reference<Plan> plan = planQuery(ucx, selector);
 		plan = ref(new FindAndModifyPlan(plan, updater, upserter, projection, ordering, isnew, ucx,
-		                                 ref(new DocInserter(ec->getChangeStream())), ec->docLayer->database, ec->mm));
+		                                 ref(new DocInserter(ec->getWatcher())), ec->docLayer->database, ec->mm));
 
 		state std::pair<int64_t, Reference<ScanReturnedContext>> pair =
 		    wait(executeUntilCompletionAndReturnLastTransactionally(plan, tr));

--- a/src/ExtCmd.actor.cpp
+++ b/src/ExtCmd.actor.cpp
@@ -592,7 +592,7 @@ ACTOR static Future<Reference<ExtMsgReply>> doFindAndModify(Reference<ExtConnect
 
 		state Reference<Plan> plan = planQuery(ucx, selector);
 		plan = ref(new FindAndModifyPlan(plan, updater, upserter, projection, ordering, isnew, ucx,
-		                                 ec->docLayer->database, ec->mm));
+		                                 ref(new DocInserter()), ec->docLayer->database, ec->mm));
 
 		state std::pair<int64_t, Reference<ScanReturnedContext>> pair =
 		    wait(executeUntilCompletionAndReturnLastTransactionally(plan, tr));

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -161,7 +161,7 @@ Reference<IPredicate> queryToPredicate(bson::BSONObj const& query, bool toplevel
 
 Reference<Plan> planQuery(Reference<UnboundCollectionContext> cx, bson::BSONObj const& query) {
 	auto predicate = queryToPredicate(query, true);
-	auto simplifiedPredicate = predicate->simplify();	
+	auto simplifiedPredicate = predicate->simplify();
 
 	Reference<Plan> plan = Reference<Plan>(
 	    FilterPlan::construct_filter_plan(cx, Reference<Plan>(new TableScanPlan(cx)), simplifiedPredicate));
@@ -1276,7 +1276,7 @@ ACTOR Future<WriteCmdResult> doDeleteCmd(Namespace ns,
 
 				// TODO: BM: <rdar://problem/40661843> DocLayer: Make bulk deletes efficient
 				int64_t deletedRecords = wait(executeUntilCompletionTransactionally(plan, dtr));
-				nrDeletedRecords += deletedRecords;		
+				nrDeletedRecords += deletedRecords;
 			} catch (Error& e) {
 				TraceEvent(SevError, "ExtMsgDeleteFailure").error(e);
 				// clang-format off
@@ -1339,7 +1339,7 @@ Future<Void> doKillCursorsRun(Reference<ExtMsgKillCursors> msg, Reference<ExtCon
 	// BufferedConnection is. So do this copy for now to be conservative.
 	int32_t numberOfCursorIDs = msg->numberOfCursorIDs;
 
-	while (numberOfCursorIDs--) {				
+	while (numberOfCursorIDs--) {
 		Cursor::pluck(ec->cursors[*ptr++]);
 	}
 

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -1260,11 +1260,27 @@ ACTOR Future<WriteCmdResult> doDeleteCmd(Namespace ns,
 				Reference<Plan> plan = planQuery(cx, it->getField("q").Obj());
 				const int64_t limit = it->getField("limit").numberLong();
 				plan = deletePlan(plan, cx, limit == 0 ? std::numeric_limits<int64_t>::max() : limit);
-				plan = ec->wrapOperationPlan(plan, false, cx);
+				plan = ec->wrapOperationPlan(plan, false, cx);					
 
 				// TODO: BM: <rdar://problem/40661843> DocLayer: Make bulk deletes efficient
 				int64_t deletedRecords = wait(executeUntilCompletionTransactionally(plan, dtr));
 				nrDeletedRecords += deletedRecords;
+
+				// std::vector<Reference<IInsertOp>> inserts;
+				// Optional<IdInfo> encodedIds = Optional<IdInfo>();
+
+				// bson::BSONObj obj = BSON(
+				// 	DocLayerConstants::OP_FIELD_H << 1
+				// 	<< DocLayerConstants::OP_FIELD_NS << 100
+				// 	<< DocLayerConstants::OP_FIELD_O << "a"
+				// 	<< DocLayerConstants::OP_FIELD_OP << DocLayerConstants::OP_DELETE
+				// );
+
+				// inserts.push_back(Reference<IInsertOp>(new ExtInsert(obj, encodedIds)));
+
+				// Namespace insertNs = Namespace(DocLayerConstants::OPLOG_DB, DocLayerConstants::OPLOG_COL);
+				// Reference<Plan> secondPlan = ec->isolatedWrapOperationPlan(ref(new InsertPlan(inserts, ec->mm, insertNs)));
+				// int64_t i = wait(executeUntilCompletionTransactionally(secondPlan, dtr));
 			} catch (Error& e) {
 				TraceEvent(SevError, "ExtMsgDeleteFailure").error(e);
 				// clang-format off

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -1260,6 +1260,7 @@ ACTOR Future<WriteCmdResult> doDeleteCmd(Namespace ns,
 				Reference<Plan> plan = planQuery(cx, it->getField("q").Obj());
 				const int64_t limit = it->getField("limit").numberLong();
 				plan = deletePlan(plan, cx, limit == 0 ? std::numeric_limits<int64_t>::max() : limit);
+				plan = oplogDeletePlan(plan, ec->mm);
 				plan = ec->wrapOperationPlan(plan, false, cx);					
 
 				// TODO: BM: <rdar://problem/40661843> DocLayer: Make bulk deletes efficient

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -1266,7 +1266,7 @@ ACTOR Future<WriteCmdResult> doDeleteCmd(Namespace ns,
 				Reference<Plan> plan = planQuery(cx, it->getField("q").Obj());
 				const int64_t limit = it->getField("limit").numberLong();
 				plan = deletePlan(plan, cx, limit == 0 ? std::numeric_limits<int64_t>::max() : limit);
-				plan = ec->wrapOperationPlan(plan, false, cx);					
+				plan = ec->wrapOperationPlanOplog(plan, ref(new DocInserter()), cx);
 
 				// TODO: BM: <rdar://problem/40661843> DocLayer: Make bulk deletes efficient
 				int64_t deletedRecords = wait(executeUntilCompletionTransactionally(plan, dtr));

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -414,6 +414,7 @@ ACTOR static Future<Void> runQuery(Reference<ExtConnection> ec,
 		                                : msg->query.hasField(DocLayerConstants::QUERY_OPERATOR.c_str())
 		                                      ? msg->query.getObjectField(DocLayerConstants::QUERY_OPERATOR.c_str())
 		                                      : msg->query;
+		fprintf(stdout, "===== QQQ OOOO: %s\n", queryObject.toString().c_str());
 
 		// Plan needs to be state in case we have a sort plan, which in turn holds a reference to the actor that does
 		// the sorting

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -1181,7 +1181,11 @@ ACTOR static Future<Void> doGetMoreRun(Reference<ExtMsgGetMore> getMore, Referen
 	state Reference<ExtMsgReply> reply = Reference<ExtMsgReply>(new ExtMsgReply(getMore->header));
 	state Reference<Cursor> cursor = ec->cursors[getMore->cursorID];
 
-	if (cursor) {
+	if (!cursor) {
+		cursor = Cursor::get(getMore->cursorID);
+	}
+
+	if (cursor) {	
 		try {
 			int32_t returned = wait(addDocumentsFromCursor(cursor, reply, getMore->numberToReturn));
 			reply->replyHeader.startingFrom = cursor->returned - returned;
@@ -1334,7 +1338,7 @@ Future<Void> doKillCursorsRun(Reference<ExtMsgKillCursors> msg, Reference<ExtCon
 	// BufferedConnection is. So do this copy for now to be conservative.
 	int32_t numberOfCursorIDs = msg->numberOfCursorIDs;
 
-	while (numberOfCursorIDs--) {
+	while (numberOfCursorIDs--) {				
 		Cursor::pluck(ec->cursors[*ptr++]);
 	}
 

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -1321,7 +1321,7 @@ ACTOR Future<WriteCmdResult> doDeleteCmd(Namespace ns,
 				Reference<Plan> plan = planQuery(cx, it->getField("q").Obj());
 				const int64_t limit = it->getField("limit").numberLong();
 				plan = deletePlan(plan, cx, limit == 0 ? std::numeric_limits<int64_t>::max() : limit);
-				plan = ec->wrapOperationPlan(plan, false, cx);			
+				plan = ec->wrapOperationPlan(plan, false, cx);					
 
 				// TODO: BM: <rdar://problem/40661843> DocLayer: Make bulk deletes efficient
 				int64_t deletedRecords = wait(executeUntilCompletionTransactionally(plan, dtr));

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -896,7 +896,7 @@ ACTOR Future<WriteCmdResult> doInsertCmd(Namespace ns,
 	Reference<Plan> plan = ref(new InsertPlan(inserts, ec->mm, ns));
 
 	if (strcmp(ns.first.c_str(), DocLayerConstants::OPLOG_DB.c_str()) != 0) {
-		plan = oplogInsertPlan(plan, documents, ref(new DocInserter()), ec->mm, ns);
+		plan = oplogInsertPlan(plan, documents, ref(new DocInserter(ec->getChangeStream())), ec->mm, ns);
 	}
 
 	plan = ec->isolatedWrapOperationPlan(plan);
@@ -1107,7 +1107,7 @@ ACTOR Future<WriteCmdResult> doUpdateCmd(Namespace ns,
 			Reference<Plan> plan = planQuery(cx, cmd->selector);
 			plan =
 			    ref(new UpdatePlan(plan, updater, upserter, cmd->multi ? std::numeric_limits<int64_t>::max() : 1, cx));
-			plan = ec->wrapOperationPlanOplog(plan, ref(new DocInserter()), cx);
+			plan = ec->wrapOperationPlanOplog(plan, ref(new DocInserter(ec->getChangeStream())), cx);
 
 			std::pair<int64_t, Reference<ScanReturnedContext>> pair =
 			    wait(executeUntilCompletionAndReturnLastTransactionally(plan, dtr));
@@ -1266,7 +1266,7 @@ ACTOR Future<WriteCmdResult> doDeleteCmd(Namespace ns,
 				Reference<Plan> plan = planQuery(cx, it->getField("q").Obj());
 				const int64_t limit = it->getField("limit").numberLong();
 				plan = deletePlan(plan, cx, limit == 0 ? std::numeric_limits<int64_t>::max() : limit);
-				plan = ec->wrapOperationPlanOplog(plan, ref(new DocInserter()), cx);
+				plan = ec->wrapOperationPlanOplog(plan, ref(new DocInserter(ec->getChangeStream())), cx);
 
 				// TODO: BM: <rdar://problem/40661843> DocLayer: Make bulk deletes efficient
 				int64_t deletedRecords = wait(executeUntilCompletionTransactionally(plan, dtr));
@@ -1462,5 +1462,6 @@ Reference<IInsertOp> operatorUpsert(bson::BSONObj const& selector, bson::BSONObj
 }
 
 Future<Reference<IReadWriteContext>> DocInserter::insert(Reference<CollectionContext> cx, bson::BSONObj obj) {
+	changeStream->writeMessage(StringRef((const uint8_t*)obj.objdata(), obj.objsize()));
 	return insertDocument(cx, obj, Optional<IdInfo>());
 }

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -146,10 +146,11 @@ Reference<IPredicate> queryToPredicate(bson::BSONObj const& query, bool toplevel
 			}
 		} else if (el.isABSONObj() && !is_literal_match(el.Obj())) {
 			// If this is a top-level _id path then force use of elemMatch because _id can NOT be an array.
-			if (toplevel && strcmp(el.fieldName(), DocLayerConstants::ID_FIELD) == 0)
-				terms.push_back(ExtValueOperator::toPredicate("$elemMatch", el.fieldName(), el));
-			else
-				valueQueryToPredicates(el.Obj(), el.fieldName(), terms);
+			// TODO: Fix. It isn't working for {_id: {"$in":[...]}}
+			//if (toplevel && strcmp(el.fieldName(), DocLayerConstants::ID_FIELD) == 0)
+			//	terms.push_back(ExtValueOperator::toPredicate("$elemMatch", el.fieldName(), el));
+			//else
+			valueQueryToPredicates(el.Obj(), el.fieldName(), terms);
 		} else {
 			terms.push_back(eq_predicate(el, el.fieldName()));
 		}
@@ -160,7 +161,7 @@ Reference<IPredicate> queryToPredicate(bson::BSONObj const& query, bool toplevel
 
 Reference<Plan> planQuery(Reference<UnboundCollectionContext> cx, bson::BSONObj const& query) {
 	auto predicate = queryToPredicate(query, true);
-	auto simplifiedPredicate = predicate->simplify();
+	auto simplifiedPredicate = predicate->simplify();	
 
 	Reference<Plan> plan = Reference<Plan>(
 	    FilterPlan::construct_filter_plan(cx, Reference<Plan>(new TableScanPlan(cx)), simplifiedPredicate));

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -414,7 +414,6 @@ ACTOR static Future<Void> runQuery(Reference<ExtConnection> ec,
 		                                : msg->query.hasField(DocLayerConstants::QUERY_OPERATOR.c_str())
 		                                      ? msg->query.getObjectField(DocLayerConstants::QUERY_OPERATOR.c_str())
 		                                      : msg->query;
-		fprintf(stdout, "===== QQQ OOOO: %s\n", queryObject.toString().c_str());
 
 		// Plan needs to be state in case we have a sort plan, which in turn holds a reference to the actor that does
 		// the sorting

--- a/src/ExtMsg.actor.h
+++ b/src/ExtMsg.actor.h
@@ -35,6 +35,7 @@
 #include "QLPlan.actor.h"
 #include "QLPredicate.h"
 #include "QLOperations.h"
+#include "Oplogger.h"
 
 #include "flow/flow.h"
 
@@ -236,6 +237,13 @@ struct ExtMsgKillCursors : ExtMsg, FastAllocated<ExtMsgKillCursors> {
 private:
 	ExtMsgKillCursors(ExtMsgHeader*, const uint8_t*);
 	friend struct ExtMsg::Factory<ExtMsgKillCursors>;
+};
+
+struct DocInserter: IOplogInserter, ReferenceCounted<DocInserter> {
+	void addref() override { ReferenceCounted<DocInserter>::addref(); }
+	void delref() override { ReferenceCounted<DocInserter>::delref(); }
+	
+	Future<Reference<IReadWriteContext>> insert(Reference<CollectionContext> cx, bson::BSONObj obj) override;
 };
 
 struct OplogInserter: ReferenceCounted<OplogInserter> {

--- a/src/ExtMsg.actor.h
+++ b/src/ExtMsg.actor.h
@@ -239,7 +239,7 @@ private:
 	friend struct ExtMsg::Factory<ExtMsgKillCursors>;
 };
 
-struct DocInserter: IOplogInserter, ReferenceCounted<DocInserter> {
+struct DocInserter: IOplogInserter, ReferenceCounted<DocInserter>, FastAllocated<DocInserter> {
 	Reference<ExtChangeWatcher> watcher;
 
 	void addref() override { ReferenceCounted<DocInserter>::addref(); }

--- a/src/ExtMsg.actor.h
+++ b/src/ExtMsg.actor.h
@@ -240,12 +240,12 @@ private:
 };
 
 struct DocInserter: IOplogInserter, ReferenceCounted<DocInserter> {
-	Reference<ExtChangeStream> changeStream;
+	Reference<ExtChangeWatcher> watcher;
 
 	void addref() override { ReferenceCounted<DocInserter>::addref(); }
 	void delref() override { ReferenceCounted<DocInserter>::delref(); }
 	
-	DocInserter(Reference<ExtChangeStream> changeStream): changeStream(changeStream) {};
+	DocInserter(Reference<ExtChangeWatcher> watcher): watcher(watcher) {};
 	Future<Reference<IReadWriteContext>> insert(Reference<CollectionContext> cx, bson::BSONObj obj) override;
 };
 

--- a/src/ExtMsg.actor.h
+++ b/src/ExtMsg.actor.h
@@ -240,9 +240,12 @@ private:
 };
 
 struct DocInserter: IOplogInserter, ReferenceCounted<DocInserter> {
+	Reference<ExtChangeStream> changeStream;
+
 	void addref() override { ReferenceCounted<DocInserter>::addref(); }
 	void delref() override { ReferenceCounted<DocInserter>::delref(); }
 	
+	DocInserter(Reference<ExtChangeStream> changeStream): changeStream(changeStream) {};
 	Future<Reference<IReadWriteContext>> insert(Reference<CollectionContext> cx, bson::BSONObj obj) override;
 };
 

--- a/src/ExtMsg.actor.h
+++ b/src/ExtMsg.actor.h
@@ -259,6 +259,8 @@ struct OplogInserter: ReferenceCounted<OplogInserter> {
 	Future<Reference<UnboundCollectionContext>> getUnboundContext(
 		Reference<MetadataManager> mm, Reference<DocTransaction> tr);
 
+	bool isValidNs(std::string ns);
+
 	private:
 		void prepareBuilder(bson::BSONObjBuilder* builder, std::string op, std::string ns);
 		Future<Reference<IReadWriteContext>> insert(Reference<CollectionContext> cx, bson::BSONObj obj);

--- a/src/ExtMsg.actor.h
+++ b/src/ExtMsg.actor.h
@@ -246,34 +246,6 @@ struct DocInserter: IOplogInserter, ReferenceCounted<DocInserter> {
 	Future<Reference<IReadWriteContext>> insert(Reference<CollectionContext> cx, bson::BSONObj obj) override;
 };
 
-struct OplogInserter: ReferenceCounted<OplogInserter> {
-	Namespace ns;
-
-	OplogInserter() {
-		ns = Namespace(DocLayerConstants::OPLOG_DB, DocLayerConstants::OPLOG_COL);
-	}
-
-	Future<Reference<IReadWriteContext>> insertOp(Reference<CollectionContext> cx, 
-												 std::string ns, 
-												 bson::BSONObj obj);
-	Future<Reference<IReadWriteContext>> updateOp(Reference<CollectionContext> cx, 
-												  std::string ns, 
-												  bson::OID id, 
-												  bson::BSONObj obj);
-	Future<Reference<IReadWriteContext>> deleteOp(Reference<CollectionContext> cx, 
-												  std::string ns, 
-												  bson::OID id);
-
-	Future<Reference<UnboundCollectionContext>> getUnboundContext(
-		Reference<MetadataManager> mm, Reference<DocTransaction> tr);
-
-	bool isValidNs(std::string ns);
-
-	private:
-		void prepareBuilder(bson::BSONObjBuilder* builder, std::string op, std::string ns);
-		Future<Reference<IReadWriteContext>> insert(Reference<CollectionContext> cx, bson::BSONObj obj);
-};
-
 Reference<Plan> planQuery(Reference<UnboundCollectionContext> cx, const bson::BSONObj& query);
 std::vector<std::string> staticValidateUpdateObject(bson::BSONObj update, bool multi, bool upsert);
 ACTOR Future<WriteCmdResult> attemptIndexInsertion(bson::BSONObj firstDoc,

--- a/src/ExtStructs.actor.cpp
+++ b/src/ExtStructs.actor.cpp
@@ -26,6 +26,12 @@ Reference<DocTransaction> ExtConnection::getOperationTransaction() {
 	return NonIsolatedPlan::newTransaction(docLayer->database);
 }
 
+Reference<Plan> ExtConnection::wrapOperationPlanOplog(Reference<Plan> plan,
+												   	  Reference<IOplogInserter> oplogInserter,
+                                                      Reference<UnboundCollectionContext> cx) {
+   return Reference<Plan>(new NonIsolatedPlan(plan, false, cx, docLayer->database, oplogInserter, mm));
+}
+
 Reference<Plan> ExtConnection::wrapOperationPlan(Reference<Plan> plan,
                                                  bool isReadOnly,
                                                  Reference<UnboundCollectionContext> cx) {

--- a/src/ExtStructs.actor.cpp
+++ b/src/ExtStructs.actor.cpp
@@ -56,7 +56,7 @@ ACTOR void watcherTimestampUpdateActor(Reference<DocumentLayer> docLayer, double
 							3, 5000));
 		wait(fwrite);
 	} catch(Error &e) {
-		fprintf(stdout, "ERRROR: %s\n", e.what());
+		fprintf(stderr, "Unable to update timestamp: %s\n", e.what());
 	}
 }
 

--- a/src/ExtStructs.actor.cpp
+++ b/src/ExtStructs.actor.cpp
@@ -48,7 +48,6 @@ ACTOR void watcherTimestampUpdateActor(Reference<DocumentLayer> docLayer, double
 	FDB::Value tsVal = tupleVal.pack();
 
 	try {
-		fprintf(stdout, "SET: %lf\n", ts);
 		Future<Void> fwrite = wait(runTransactionAsync(docLayer->database,
 							[&, tsVal](Reference<DocTransaction> tr) {								
 								tr->tr->set(tsKey, tsVal);
@@ -93,9 +92,6 @@ ACTOR void watcherTimestampWatchingActor(Reference<DocumentLayer> docLayer, Refe
 			if (lastTs == newTs) {
 				continue;
 			}
-
-			fprintf(stdout, "TS Last: %lf, New: %lf\n", lastTs, newTs);
-			fprintf(stdout, "TODO: SCAN COLLECTION\n");
 
 			Namespace ns = Namespace(DocLayerConstants::OPLOG_DB, DocLayerConstants::OPLOG_COL);
 			state Reference<DocTransaction> dtr = NonIsolatedPlan::newTransaction(docLayer->database);

--- a/src/ExtStructs.h
+++ b/src/ExtStructs.h
@@ -108,6 +108,7 @@ struct ExtChangeStream : ReferenceCounted<ExtChangeStream>, NonCopyable {
 	void deleteConnection(int64_t connectionId);
 	void writeMessage(Standalone<StringRef> msg);
 	void clear();
+	int countConnections();
 };
 
 struct ExtChangeWatcher: ReferenceCounted<ExtChangeWatcher>, NonCopyable {

--- a/src/ExtStructs.h
+++ b/src/ExtStructs.h
@@ -139,7 +139,7 @@ struct ExtConnection : ReferenceCounted<ExtConnection>, NonCopyable {
 	Future<WriteResult> lastWrite;
 	Reference<ExtChangeWatcher> watcher;
 
-	Reference<DocTransaction> getOperationTransaction();	
+	Reference<DocTransaction> getOperationTransaction();
 	Reference<Plan> wrapOperationPlan(Reference<Plan> plan, bool isReadOnly, Reference<UnboundCollectionContext> cx);
 	Reference<Plan> isolatedWrapOperationPlan(Reference<Plan> plan);
 	Reference<Plan> isolatedWrapOperationPlan(Reference<Plan> plan, int64_t timeout, int64_t retryLimit);

--- a/src/ExtStructs.h
+++ b/src/ExtStructs.h
@@ -114,10 +114,16 @@ struct ExtChangeStream : ReferenceCounted<ExtChangeStream>, NonCopyable {
 struct ExtChangeWatcher: ReferenceCounted<ExtChangeWatcher>, NonCopyable {
 	Reference<DocumentLayer> docLayer;
 	Reference<ExtChangeStream> changeStream;
-	FDB::Key tsKey;
+	FutureStream<double> tsStreamReader;
+	PromiseStream<double> tsStreamWriter;
+	PromiseStream<double> tsScanPromise;
+	FutureStream<double> tsScanFuture;
 
 	ExtChangeWatcher(Reference<DocumentLayer> docLayer, Reference<ExtChangeStream> changeStream): 
-	docLayer(docLayer), changeStream(changeStream) {};
+	docLayer(docLayer), changeStream(changeStream) {
+		tsStreamReader = tsStreamWriter.getFuture();
+		tsScanFuture = tsScanPromise.getFuture();
+	};
 
 	void update(double timestamp);
 	void watch();
@@ -132,9 +138,6 @@ struct ExtConnection : ReferenceCounted<ExtConnection>, NonCopyable {
 	Reference<BufferedConnection> bc;
 	Future<WriteResult> lastWrite;
 	Reference<ExtChangeWatcher> watcher;
-
-	Reference<ExtChangeWatcher> getWatcher();
-	void setWatcher(Reference<ExtChangeWatcher> watcher);
 
 	Reference<DocTransaction> getOperationTransaction();	
 	Reference<Plan> wrapOperationPlan(Reference<Plan> plan, bool isReadOnly, Reference<UnboundCollectionContext> cx);

--- a/src/ExtStructs.h
+++ b/src/ExtStructs.h
@@ -30,6 +30,7 @@
 #include "BufferedConnection.h"
 #include "DocLayer.h"
 #include "MetadataManager.h"
+#include "Oplogger.h"
 
 #include "QLPlan.actor.h"
 
@@ -109,10 +110,13 @@ struct ExtConnection : ReferenceCounted<ExtConnection>, NonCopyable {
 	Reference<BufferedConnection> bc;
 	Future<WriteResult> lastWrite;
 
-	Reference<DocTransaction> getOperationTransaction();
+	Reference<DocTransaction> getOperationTransaction();	
 	Reference<Plan> wrapOperationPlan(Reference<Plan> plan, bool isReadOnly, Reference<UnboundCollectionContext> cx);
 	Reference<Plan> isolatedWrapOperationPlan(Reference<Plan> plan);
 	Reference<Plan> isolatedWrapOperationPlan(Reference<Plan> plan, int64_t timeout, int64_t retryLimit);
+	Reference<Plan> wrapOperationPlanOplog(Reference<Plan> plan,
+										Reference<IOplogInserter> oplogInserter, 
+										Reference<UnboundCollectionContext> cx);
 	void startHousekeeping();
 	Future<Void> beforeWrite(int desiredPermits = 1);
 	Future<Void> afterWrite(Future<WriteResult> result, int releasePermits = 1);

--- a/src/ExtUtil.actor.cpp
+++ b/src/ExtUtil.actor.cpp
@@ -612,18 +612,16 @@ bson::BSONObj getUpdatedObjectsDifference(bson::BSONObj original, bson::BSONObj 
 
 		auto sibbling = original.getField(nextField);
 
-		if (next.isSimpleType() || next.type() == bson::Array) {
-			if (!next.valuesEqual(sibbling)) {
-				builder.append(next);				
-			}
-			continue;
-		}
-
 		if (next.type() == bson::Object) {
 			auto child = getUpdatedObjectsDifference(sibbling.Obj(), next.Obj(), isSet);
 			if (!child.isEmpty()) {
 				builder.append(nextField, child);
 			}
+			continue;
+		}
+
+		if (!next.valuesEqual(sibbling)) {
+			builder.append(next);
 		}
 	}
 

--- a/src/ExtUtil.actor.h
+++ b/src/ExtUtil.actor.h
@@ -125,6 +125,11 @@ Reference<IPredicate> re_predicate(const bson::BSONElement& el, const std::strin
 bson::BSONObj sortBsonObj(bson::BSONObj obj);
 
 /**
+ * Return a difference between bson objects `original` and `updated`
+ */
+bson::BSONObj getUpdatedObjectsDifference(bson::BSONObj original, bson::BSONObj updated, bool isSet = true);
+
+/**
  * Return a pair of key-encoded and value-encoded strings of whatever was in the _id
  * field of `obj`, plus the value itself if it was a bson object.
  */

--- a/src/OplogMonitor.actor.cpp
+++ b/src/OplogMonitor.actor.cpp
@@ -206,7 +206,6 @@ ACTOR void deleteExpiredLogs(Reference<DocumentLayer> docLayer, double ts) {
 		} catch (Error& e) {
 			if (e.code() == error_code_collection_not_found)
 				return;
-
 			throw e;
 		}
 	

--- a/src/OplogMonitor.actor.cpp
+++ b/src/OplogMonitor.actor.cpp
@@ -216,7 +216,7 @@ ACTOR void deleteExpiredLogs(Reference<DocumentLayer> docLayer, double ts) {
 			plan = Reference<Plan>(new NonIsolatedPlan(plan, false, cx, docLayer->database, docLayer->mm));
 			int64_t _ = wait(executeUntilCompletionTransactionally(plan, dtr));
 		} catch (Error& e) {
-			fprintf(stderr, "Unable to delete oplog by ts %f\n", ts);			
+			fprintf(stderr, "Unable to delete oplog by ts %f\n", ts);
 		}
 }
 

--- a/src/OplogMonitor.actor.cpp
+++ b/src/OplogMonitor.actor.cpp
@@ -1,0 +1,247 @@
+/*
+ * OplogMonitor.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OplogMonitor.h"
+#include "ExtUtil.actor.h"
+#include "ExtMsg.actor.h"
+#include "flow/actorcompiler.h" // This must be the last #include.
+
+using namespace FDB;
+
+// Send timestamp to stream
+void sendTimestamp(PromiseStream<double> times, double ts) {
+	try {
+		times.send(ts);
+	} catch(Error &e) {
+		fprintf(stdout, "Timestamp send error: %s\n", e.what());
+	}
+}
+
+// Get timestamp directory storage
+ACTOR Future<Reference<DirectorySubspace>> watcherGetTSDirectory(Reference<DocumentLayer> docLayer) {
+	Reference<DirectoryLayer> d = Reference<DirectoryLayer>(new DirectoryLayer());
+	Reference<DirectorySubspace> ds = wait(runRYWTransaction(docLayer->database, [d](Reference<DocTransaction> tr) {
+		    return d->createOrOpen(tr->tr, {LiteralStringRef("Oplog"), LiteralStringRef("Updates")});
+	    },
+	    -1, 0));
+
+	return ds;
+}
+
+// Get timestamp subspace key
+FDB::Key watcherGetTSKey(Reference<DirectorySubspace> dir) {
+	return dir->pack(LiteralStringRef("timestamp"), true);
+}
+
+// Run timestamp stream watcher
+ACTOR void watcherTimestampUpdateActor(Reference<DocumentLayer> docLayer, FutureStream<double> times) {
+	state Reference<DirectorySubspace> timestampDir = wait(watcherGetTSDirectory(docLayer));
+	state FDB::Key tsKey = watcherGetTSKey(timestampDir);
+	state double ts = 0.0;
+
+	loop {
+		try {
+			try {
+				state Future<Void> timeout = Never();
+				state int cnt = 0;
+
+				loop choose {
+					when(double tmpTs = waitNext(times)) {																
+						ts = tmpTs;
+						cnt++;
+
+						if (cnt == 1) {
+							timeout = delay(0.1, TaskMaxPriority);
+						}
+
+						if (cnt == 5) {
+							timeout = delay(0.3, TaskMaxPriority);
+						}
+
+						if (cnt >= 500) {
+							throw end_of_stream();
+						}
+					}										
+					when(wait(timeout)) {
+						throw end_of_stream();
+					}
+				}
+			} catch (Error& e) {
+				if (e.code() != error_code_end_of_stream)
+					throw;
+			}
+
+			state Reference<DocTransaction> updTr = NonIsolatedPlan::newTransaction(docLayer->database);
+			updTr->tr->atomicOp(tsKey, StringRef((const uint8_t*)&ts, sizeof(double)), FDB_MUTATION_TYPE_MAX);
+			wait(updTr->tr->commit());
+		} catch(Error &e) {
+			fprintf(stderr, "Watcher ts update error: %s\n", e.what());
+		}
+	}
+}
+
+// Scan updates from oplog and send to change stream
+ACTOR void watcherScanUpdates(FutureStream<double> times, Reference<DocumentLayer> docLayer, Reference<ExtChangeStream> changeStream) {
+	state double lastTs = -1.0;
+	state Namespace ns = Namespace(DocLayerConstants::OPLOG_DB, DocLayerConstants::OPLOG_COL);
+
+	loop {
+		try {
+			state double newTs = waitNext(times);
+			if (lastTs == -1.0) {
+				lastTs = newTs;
+				continue;
+			}
+			if (lastTs == newTs) {
+				continue;
+			}
+
+			if (changeStream->countConnections() > 0) {
+				state Reference<DocTransaction> dtr = NonIsolatedPlan::newTransaction(docLayer->database);
+				state Reference<UnboundCollectionContext> cx = wait(docLayer->mm->getUnboundCollectionContext(dtr, ns, true));				
+				bson::BSONObj query = BSON("ts" << BSON("$gt" << lastTs << "$lte" << newTs));
+		
+				state Reference<PlanCheckpoint> checkpoint(new PlanCheckpoint);
+				state Reference<Plan> plan = planQuery(cx, query);
+				plan = Reference<Plan>(new NonIsolatedPlan(plan, true, cx, docLayer->database, docLayer->mm));
+				state FutureStream<Reference<ScanReturnedContext>> docs = plan->execute(checkpoint.getPtr(), dtr);
+				state FlowLock* flowControlLock = checkpoint->getDocumentFinishedLock();
+
+				try {
+					loop {
+						choose {
+							when(state Reference<ScanReturnedContext> doc = waitNext(docs)) {
+								DataValue oDv = wait(doc->toDataValue());
+								bson::BSONObj obj = oDv.getPackedObject().getOwned();
+								flowControlLock->release();
+								changeStream->writeMessage(StringRef((const uint8_t*)obj.objdata(), obj.objsize()));
+							}
+						}
+					}
+				} catch (Error& e) {
+					checkpoint->stop();
+					if (e.code() != error_code_end_of_stream) {						
+						throw;
+					}
+				}
+			}
+
+			lastTs = newTs;
+		} catch(Error &e) {
+			fprintf(stderr, "Watcher scan error: %s\n", e.what());
+		}
+	}
+}
+
+// Run timestamp watcher
+ACTOR void watcherTimestampWatchingActor(PromiseStream<double> times, Reference<DocumentLayer> docLayer) {
+	state Reference<DirectorySubspace> timestampDir = wait(watcherGetTSDirectory(docLayer));
+	state FDB::Key tsKey = watcherGetTSKey(timestampDir);
+	state double ts = 0.0;
+	state double prevTs = -1.0;
+
+	loop {
+		try {
+			state Reference<DocTransaction> dtr = NonIsolatedPlan::newTransaction(docLayer->database);
+			state Future<Void> watch = dtr->tr->watch(tsKey);
+			state Future<Optional<FDBStandalone<StringRef>>> futureTs = dtr->tr->get(tsKey);			
+			wait(dtr->tr->commit());
+			dtr->tr->reset();
+
+			Optional<FDBStandalone<StringRef>> tsBefore = wait(futureTs);
+			if (tsBefore.present()) {
+				ts = *(double*)tsBefore.get().begin();
+			}
+
+			if (ts == prevTs) {
+				wait(watch || delay(5.0));
+				futureTs = dtr->tr->get(tsKey);
+				wait(dtr->tr->commit());
+
+				Optional<FDBStandalone<StringRef>> tsAfter = wait(futureTs);
+				if (tsAfter.present()) {
+					ts = *(double*)tsAfter.get().begin();
+				}
+
+				if (ts == prevTs) {
+					continue;
+				}
+			}
+	
+			prevTs = ts;
+			sendTimestamp(times, ts);
+		} catch(Error &e) {
+			fprintf(stderr, "Watcher watching error: %s\n", e.what());
+			wait(delay(1.0, TaskMaxPriority));
+		}
+	}
+}
+
+// Delete expired oplogs by timestamp
+ACTOR void deleteExpiredLogs(Reference<DocumentLayer> docLayer, double ts) {
+	state Reference<DocTransaction> dtr = NonIsolatedPlan::newTransaction(docLayer->database);
+	state Reference<UnboundCollectionContext> cx;
+	state Namespace ns = Namespace(DocLayerConstants::OPLOG_DB, DocLayerConstants::OPLOG_COL);
+
+	try {
+			Reference<UnboundCollectionContext> _cx = wait(docLayer->mm->getUnboundCollectionContext(dtr, ns, false, false));
+			cx = _cx;
+		} catch (Error& e) {
+			if (e.code() == error_code_collection_not_found)
+				return;
+			throw e;
+		}
+	
+	try {		
+			bson::BSONObj query = BSON("ts" << BSON("$lte" << ts));
+			Reference<Plan> plan = planQuery(cx, query);
+			plan = deletePlan(plan, cx, std::numeric_limits<int64_t>::max());
+			plan = Reference<Plan>(new NonIsolatedPlan(plan, true, cx, docLayer->database, docLayer->mm));
+			int64_t _ = wait(executeUntilCompletionTransactionally(plan, dtr));
+		} catch (Error& e) {
+			TraceEvent(SevError, "OplogMonitorDeleteFailure").error(e);
+			fprintf(stderr, "Unable to delete oplog by ts %f\n", ts);			
+		}
+}
+
+// sendTimestamp helper
+void oplogSendTimestamp(PromiseStream<double> times, double ts) {
+    sendTimestamp(times, ts);
+}
+
+// watcherScanUpdates helper
+void oplogRunUpdateScanner(FutureStream<double> times, Reference<DocumentLayer> docLayer, Reference<ExtChangeStream> changeStream) {
+    watcherScanUpdates(times, docLayer, changeStream);
+}
+
+// watcherTimestampUpdateActor helper
+void oplogRunStreamWatcher(Reference<DocumentLayer> docLayer, FutureStream<double> times) {
+    watcherTimestampUpdateActor(docLayer, times);
+}
+
+// watcherTimestampWatchingActor helper
+void oplogRunTimestampWatcher(PromiseStream<double> times, Reference<DocumentLayer> docLayer) {
+    watcherTimestampWatchingActor(times, docLayer);
+}
+
+// Run oplog size monitor
+void oplogMonitor(Reference<DocumentLayer> docLayer, double logsDeletionOffset) {
+	deleteExpiredLogs(docLayer, timer() * 1000 - logsDeletionOffset);
+}

--- a/src/OplogMonitor.h
+++ b/src/OplogMonitor.h
@@ -1,0 +1,37 @@
+/*
+ * OplogMonitor.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _OPLOG_MONITOR_H
+#define _OPLOG_MONITOR_H
+#pragma once
+
+#include "bindings/flow/fdb_flow.h"
+#include "bindings/flow/DirectorySubspace.h"
+#include "flow/flow.h"
+#include "DocLayer.h"
+#include "ExtStructs.h"
+
+
+void oplogSendTimestamp(PromiseStream<double> times, double ts);
+void oplogRunUpdateScanner(FutureStream<double> times, Reference<DocumentLayer> docLayer, Reference<ExtChangeStream> changeStream);
+void oplogRunStreamWatcher(Reference<DocumentLayer> docLayer, FutureStream<double> times);
+void oplogRunTimestampWatcher(PromiseStream<double> times, Reference<DocumentLayer> docLayer);
+void oplogMonitor(Reference<DocumentLayer> docLayer, double logsDeletionOffset);
+
+#endif /* _OPLOG_MONITOR_H */

--- a/src/OplogMonitor.h
+++ b/src/OplogMonitor.h
@@ -27,7 +27,6 @@
 #include "DocLayer.h"
 #include "ExtStructs.h"
 
-
 void oplogSendTimestamp(PromiseStream<double> times, double ts);
 void oplogRunUpdateScanner(FutureStream<double> times, Reference<DocumentLayer> docLayer, Reference<ExtChangeStream> changeStream);
 void oplogRunStreamWatcher(Reference<DocumentLayer> docLayer, FutureStream<double> times);

--- a/src/Oplogger.cpp
+++ b/src/Oplogger.cpp
@@ -1,0 +1,168 @@
+/*
+ * Oplogger.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * MongoDB is a registered trademark of MongoDB, Inc.
+ */
+
+#include "Oplogger.h"
+#include "ExtUtil.actor.h"
+
+Future<Reference<IReadWriteContext>> OplogActor::insertOp(Reference<CollectionContext> cx, 
+												 std::string ns, 
+												 bson::BSONObj obj) {
+    bson::BSONObjBuilder builder;
+	prepareBuilder(&builder, DocLayerConstants::OP_INSERT, ns);
+
+	builder.append(DocLayerConstants::OP_FIELD_O, obj);
+
+	return inserter->insert(cx, builder.obj());
+}
+
+Future<Reference<IReadWriteContext>> OplogActor::updateOp(Reference<CollectionContext> cx, 
+                                                std::string ns, 
+                                                bson::OID id, 
+                                                bson::BSONObj obj) {
+    bson::BSONObjBuilder builder;
+	prepareBuilder(&builder, DocLayerConstants::OP_UPDATE, ns);
+
+	builder.append(DocLayerConstants::OP_FIELD_O2, BSON(DocLayerConstants::ID_FIELD << id.toString()))
+		   .append(DocLayerConstants::OP_FIELD_O, BSON("v" << 1 << "set" << obj));
+
+	return inserter->insert(cx, builder.obj());
+}
+
+Future<Reference<IReadWriteContext>> OplogActor::deleteOp(Reference<CollectionContext> cx, 
+                                                std::string ns, 
+                                                bson::OID id) {
+    bson::BSONObjBuilder builder;
+	prepareBuilder(&builder, DocLayerConstants::OP_DELETE, ns);
+
+	builder.append(DocLayerConstants::OP_FIELD_O, BSON(DocLayerConstants::ID_FIELD << id.toString()));
+
+	return inserter->insert(cx, builder.obj());
+}
+
+void OplogActor::prepareBuilder(bson::BSONObjBuilder* builder, std::string op, std::string ns) {
+	(*builder).append(DocLayerConstants::OP_FIELD_TS, (long long)(timer() * 1000))
+		   	  .append(DocLayerConstants::OP_FIELD_V, int32_t(2))
+		   	  .append(DocLayerConstants::OP_FIELD_H, (long long)(g_random->randomInt64(INT64_MIN, INT64_MAX)))
+		      .append(DocLayerConstants::OP_FIELD_NS, ns)
+		      .append(DocLayerConstants::OP_FIELD_OP, op);
+}
+
+Oplogger::Oplogger(Namespace operationNs, Reference<IOplogInserter> oplogInserter) {
+    ns = fullCollNameToString(operationNs);
+    actor = ref(new OplogActor(oplogInserter));
+    oplogNs = Namespace(DocLayerConstants::OPLOG_DB, DocLayerConstants::OPLOG_COL);
+    enabled = isValidNamespace(ns) && oplogInserter.isValid();
+}
+
+void Oplogger::reset() { 
+    operations.clear(); 
+}
+
+bool Oplogger::isEnabled() {
+    return enabled; 
+}
+
+Deque<Future<Reference<IReadWriteContext>>> Oplogger::buildOplogs(Reference<CollectionContext> ctx) {
+    Deque<Future<Reference<IReadWriteContext>>> oplogs;
+
+    for(auto o : operations) {
+        if (o.second.second.isEmpty()) {
+            oplogs.push_back(actor->deleteOp(ctx, ns, bson::OID(o.first)));
+            continue;
+        }
+
+        if (o.second.first.isEmpty()) {
+            oplogs.push_back(actor->insertOp(ctx, ns, o.second.second));
+            continue;
+        }
+
+        oplogs.push_back(actor->updateOp(ctx, ns, bson::OID(o.first), o.second.second));
+    }
+
+    return oplogs;
+}
+
+void Oplogger::addOriginalDoc(const DataValue *dv) {
+	bson::BSONObj oObj = dv->getPackedObject().getOwned();
+    gatherObjectsInfo(oObj, true);
+}
+
+void Oplogger::addUpdatedDoc(const DataValue *dv) {
+	bson::BSONObj oObj = dv->getPackedObject().getOwned();
+    gatherObjectsInfo(oObj, false);
+}
+
+void Oplogger::addOriginalDoc(bson::BSONObj doc) {
+    gatherObjectsInfo(doc, true);
+}
+
+void Oplogger::addUpdatedDoc(bson::BSONObj doc) {	
+    gatherObjectsInfo(doc, false);
+}
+
+Future<Reference<UnboundCollectionContext>> Oplogger::getUnboundContext(Reference<MetadataManager> mm, 
+                                                                        Reference<DocTransaction> tr) {
+    return mm->getUnboundCollectionContext(tr, oplogNs);
+}
+
+void Oplogger::gatherObjectsInfo(bson::BSONObj oObj, bool isSource) {
+	if (oObj.isEmpty()) {
+		return;
+	}
+
+	bson::BSONElement oId;    
+	if (!oObj.getObjectID(oId)) {
+        return;
+    }
+
+	if (oId.isNull()) {
+		return;
+	}
+
+	if (isSource) {
+		operations[oId.OID().toString()] = std::make_pair(oObj, bson::BSONObj());
+		return;
+	}
+
+	auto oIdStr = oId.OID().toString();	
+	if (operations.count(oIdStr) > 0) {
+		auto bobDiff = getUpdatedObjectsDifference(operations[oIdStr].first, oObj);
+		
+		if (bobDiff.isEmpty()) {
+			bobDiff = getUpdatedObjectsDifference(oObj, operations[oIdStr].first, false);
+		}
+
+		if (bobDiff.isEmpty()) {
+			operations.erase(oIdStr);
+			return;
+		}
+
+		operations[oIdStr].second = bobDiff;
+		return;
+	}
+	
+	operations[oIdStr] = std::make_pair(bson::BSONObj(), oObj);
+}
+
+bool Oplogger::isValidNamespace(std::string ns) {
+    return strcasecmp(ns.c_str(), fullCollNameToString(oplogNs).c_str()) != 0;
+}

--- a/src/Oplogger.h
+++ b/src/Oplogger.h
@@ -41,15 +41,15 @@ struct OplogActor: ReferenceCounted<OplogActor> {
 	OplogActor(Reference<IOplogInserter> inserter) : inserter(inserter) {}
 
 	Future<Reference<IReadWriteContext>> insertOp(Reference<CollectionContext> cx, 
-												 std::string ns, 
+												 std::string ns,
 												 bson::BSONObj obj);
 	Future<Reference<IReadWriteContext>> updateOp(Reference<CollectionContext> cx, 
 												  std::string ns, 
-												  bson::OID id, 
+												  std::string id,
 												  bson::BSONObj obj);
 	Future<Reference<IReadWriteContext>> deleteOp(Reference<CollectionContext> cx, 
-												  std::string ns, 
-												  bson::OID id);
+												  std::string ns,
+												  std::string id);
 
 	private:
 		void prepareBuilder(bson::BSONObjBuilder* builder, std::string op, std::string ns);
@@ -71,7 +71,7 @@ struct Oplogger: ReferenceCounted<Oplogger> {
     void addOriginalDoc(const DataValue *dv);
     void addUpdatedDoc(const DataValue *dv);
 	void addOriginalDoc(bson::BSONObj doc);
-	void addUpdatedDoc(bson::BSONObj doc);	
+	void addUpdatedDoc(bson::BSONObj doc);
 
 	private:
 		void gatherObjectsInfo(bson::BSONObj oObj, bool isSource);

--- a/src/Oplogger.h
+++ b/src/Oplogger.h
@@ -1,0 +1,87 @@
+/*
+ * Oplogger.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _OPLOGGER_H_
+#define _OPLOGGER_H_
+
+#pragma once
+
+#include <map>
+#include "bson.h"
+#include "flow/flow.h"
+#include "flow/FastRef.h"
+#include "MetadataManager.h"
+#include "QLContext.h"
+
+struct IOplogInserter {
+	virtual void addref() = 0;
+	virtual void delref() = 0;
+    virtual Future<Reference<IReadWriteContext>> insert(Reference<CollectionContext> cx, bson::BSONObj obj) = 0;
+};
+
+// OploagActor - documents inserter
+struct OplogActor: ReferenceCounted<OplogActor> {
+	OplogActor(Reference<IOplogInserter> inserter) : inserter(inserter) {}
+
+	Future<Reference<IReadWriteContext>> insertOp(Reference<CollectionContext> cx, 
+												 std::string ns, 
+												 bson::BSONObj obj);
+	Future<Reference<IReadWriteContext>> updateOp(Reference<CollectionContext> cx, 
+												  std::string ns, 
+												  bson::OID id, 
+												  bson::BSONObj obj);
+	Future<Reference<IReadWriteContext>> deleteOp(Reference<CollectionContext> cx, 
+												  std::string ns, 
+												  bson::OID id);
+
+	private:
+		void prepareBuilder(bson::BSONObjBuilder* builder, std::string op, std::string ns);
+    	Reference<IOplogInserter> inserter;
+};
+
+// Oplogger - documents processor
+struct Oplogger: ReferenceCounted<Oplogger> {
+    Oplogger(Namespace operationNs, Reference<IOplogInserter> oplogInserter);
+
+	// Clean operations
+    void reset();
+
+	// Checks if oplog is enabled for given namespace
+    bool isEnabled();
+
+	Future<Reference<UnboundCollectionContext>> getUnboundContext(Reference<MetadataManager> mm, Reference<DocTransaction> tr);
+    Deque<Future<Reference<IReadWriteContext>>> buildOplogs(Reference<CollectionContext> ctx);
+    void addOriginalDoc(const DataValue *dv);
+    void addUpdatedDoc(const DataValue *dv);
+	void addOriginalDoc(bson::BSONObj doc);
+	void addUpdatedDoc(bson::BSONObj doc);	
+
+	private:
+		void gatherObjectsInfo(bson::BSONObj oObj, bool isSource);
+		bool isValidNamespace(std::string ns);
+
+		Namespace oplogNs;
+		std::string ns;
+		Reference<OplogActor> actor;
+		std::map<std::string, std::pair<bson::BSONObj, bson::BSONObj>> operations;
+		bool enabled;
+};
+
+#endif

--- a/src/Oplogger.h
+++ b/src/Oplogger.h
@@ -37,7 +37,9 @@ struct IOplogInserter {
 };
 
 // OploagActor - documents inserter
-struct OplogActor: ReferenceCounted<OplogActor> {
+struct OplogActor: ReferenceCounted<OplogActor>, NonCopyable {
+	
+
 	OplogActor(Reference<IOplogInserter> inserter) : inserter(inserter) {}
 
 	Future<Reference<IReadWriteContext>> insertOp(Reference<CollectionContext> cx, 
@@ -57,7 +59,7 @@ struct OplogActor: ReferenceCounted<OplogActor> {
 };
 
 // Oplogger - documents processor
-struct Oplogger: ReferenceCounted<Oplogger> {
+struct Oplogger: ReferenceCounted<Oplogger>, NonCopyable {
     Oplogger(Namespace operationNs, Reference<IOplogInserter> oplogInserter);
 
 	// Clean operations

--- a/src/QLOperations.h
+++ b/src/QLOperations.h
@@ -51,7 +51,7 @@ struct ConcreteInsertOp : IInsertOp, ReferenceCounted<Concrete>, FastAllocated<C
 };
 
 struct DeleteDocument : ConcreteUpdateOp<DeleteDocument> {
-	Future<Void> update(Reference<IReadWriteContext> document) override {	
+	Future<Void> update(Reference<IReadWriteContext> document) override {
 		document->clearDescendants();
 		document->clearRoot();
 		return Future<Void>(Void());

--- a/src/QLOperations.h
+++ b/src/QLOperations.h
@@ -51,12 +51,12 @@ struct ConcreteInsertOp : IInsertOp, ReferenceCounted<Concrete>, FastAllocated<C
 };
 
 struct DeleteDocument : ConcreteUpdateOp<DeleteDocument> {
-	Future<Void> update(Reference<IReadWriteContext> document) override {
+	Future<Void> update(Reference<IReadWriteContext> document) override {	
 		document->clearDescendants();
 		document->clearRoot();
 		return Future<Void>(Void());
 	}
-	std::string describe() override { return "delete document"; }
+	std::string describe() override { return DocLayerConstants::DESCRIBE_DELETE_DOC; }
 };
 
 #endif

--- a/src/QLPlan.actor.cpp
+++ b/src/QLPlan.actor.cpp
@@ -88,10 +88,10 @@ Optional<Reference<Plan>> TableScanPlan::push_down(Reference<UnboundCollectionCo
                                                    Reference<IPredicate> query) {
 	switch (query->getTypeCode()) {
 	case IPredicate::ANY: {
-		auto anyPred = dynamic_cast<AnyPredicate*>(query.getPtr());
+		auto anyPred = dynamic_cast<AnyPredicate*>(query.getPtr());		
 		if (anyPred->expr->get_index_key() == DocLayerConstants::ID_FIELD) {
 			Optional<DataValue> begin, end;
-			anyPred->pred->get_range(begin, end);
+			anyPred->pred->get_range(begin, end);			
 			if (begin.present() || end.present()) {
 				if (anyPred->pred->range_is_tight()) {
 					return ref(new PrimaryKeyLookupPlan(cx, begin, end));
@@ -262,7 +262,7 @@ ACTOR static Future<Void> doFilter(PlanCheckpoint* checkpoint,
 		loop {
 			try {
 				choose {
-					when(Reference<ScanReturnedContext> nextInput = waitNext(input)) {
+					when(Reference<ScanReturnedContext> nextInput = waitNext(input)) {						
 						futures.push_back(std::pair<Reference<ScanReturnedContext>, Future<bool>>(
 						    nextInput, predicate->evaluate(nextInput)));
 					}

--- a/src/QLPlan.actor.cpp
+++ b/src/QLPlan.actor.cpp
@@ -1443,20 +1443,8 @@ ACTOR static Future<Void> projectAndUpdate(PlanCheckpoint* checkpoint,
 			firstDoc = ref(new ScanReturnedContext(inserted, -1, FDB::Key()));
 		}
 
-		if (any || upsertOp) {
-			/*
-				ProjectAndUpdate работает через этот план @PROJECTANDUPDATE
-				Документ в исходном состоянии (1) (SRC)
-			*/
-			// DataValue dv2 = wait(firstDoc->toDataValue());
-			// fprintf(stdout, "1. PROJECT AND UPDATE: %s\n", dv2.getPackedObject().toString().c_str());
-			wait(firstDoc->commitChanges());
-			/*
-				ProjectAndUpdate работает через этот план @PROJECTANDUPDATE
-				Документ в финальном состоянии (1) (DEST)
-			*/
-			// DataValue dv2 = wait(firstDoc->toDataValue());
-			// fprintf(stdout, "1. PROJECT AND UPDATE: %s\n", dv2.getPackedObject().toString().c_str());	
+		if (any || upsertOp) {			
+			wait(firstDoc->commitChanges());			
 		}
 
 		if (projectNew && (any || upsertOp)) {

--- a/src/QLPlan.actor.cpp
+++ b/src/QLPlan.actor.cpp
@@ -807,7 +807,18 @@ void gatherObjectsInfo(
 
 	auto oIdStr = oId.OID().toString();	
 	if (updates->count(oIdStr) > 0) {
-		(*updates)[oIdStr].second = oObj;
+		auto bobDiff = getUpdatedObjectsDifference((*updates)[oIdStr].first, oObj);
+		
+		if (bobDiff.isEmpty()) {
+			bobDiff = getUpdatedObjectsDifference(oObj, (*updates)[oIdStr].first, false);
+		}
+
+		if (bobDiff.isEmpty()) {
+			(*updates).erase(oIdStr);
+			return;
+		}
+
+		(*updates)[oIdStr].second = bobDiff;
 		return;
 	}
 	

--- a/src/QLPlan.actor.cpp
+++ b/src/QLPlan.actor.cpp
@@ -1158,8 +1158,8 @@ ACTOR static Future<Void> doOplogInsert(PlanCheckpoint* checkpoint,
 				throw;
 		}
 
-		if (oplogger->isEnabled()) {
-			// Oplog. Commit operations.
+		if (oplogger->isEnabled()) {			
+			// Oplog. Commit operations.			
 			state Reference<UnboundCollectionContext> ucx = wait(oplogger->getUnboundContext(mm, tr));
 			state Reference<CollectionContext> ctx = ucx->bindCollectionContext(tr);
 			
@@ -1168,7 +1168,7 @@ ACTOR static Future<Void> doOplogInsert(PlanCheckpoint* checkpoint,
 			for (; i < logs.size(); i++) {
 				Reference<IReadWriteContext> _doc = wait(logs[i]);
 				wait(_doc->commitChanges());		
-			}
+			}			
 		}
 
 		throw end_of_stream();
@@ -1269,7 +1269,7 @@ ACTOR static Future<Void> findAndModify(PlanCheckpoint* outerCheckpoint,
                                         bool projectNew,
                                         PromiseStream<Reference<ScanReturnedContext>> output) {
 	if (!dtr)
-		dtr = NonIsolatedPlan::newTransaction(database);		
+		dtr = NonIsolatedPlan::newTransaction(database);	
 	state Reference<PlanCheckpoint> innerCheckpoint(new PlanCheckpoint);
 	state int nTransactions = 1;
 	state FlowLock* outerLock = outerCheckpoint->getDocumentFinishedLock();

--- a/src/QLPlan.actor.cpp
+++ b/src/QLPlan.actor.cpp
@@ -88,10 +88,10 @@ Optional<Reference<Plan>> TableScanPlan::push_down(Reference<UnboundCollectionCo
                                                    Reference<IPredicate> query) {
 	switch (query->getTypeCode()) {
 	case IPredicate::ANY: {
-		auto anyPred = dynamic_cast<AnyPredicate*>(query.getPtr());		
+		auto anyPred = dynamic_cast<AnyPredicate*>(query.getPtr());
 		if (anyPred->expr->get_index_key() == DocLayerConstants::ID_FIELD) {
 			Optional<DataValue> begin, end;
-			anyPred->pred->get_range(begin, end);			
+			anyPred->pred->get_range(begin, end);
 			if (begin.present() || end.present()) {
 				if (anyPred->pred->range_is_tight()) {
 					return ref(new PrimaryKeyLookupPlan(cx, begin, end));
@@ -262,7 +262,7 @@ ACTOR static Future<Void> doFilter(PlanCheckpoint* checkpoint,
 		loop {
 			try {
 				choose {
-					when(Reference<ScanReturnedContext> nextInput = waitNext(input)) {						
+					when(Reference<ScanReturnedContext> nextInput = waitNext(input)) {
 						futures.push_back(std::pair<Reference<ScanReturnedContext>, Future<bool>>(
 						    nextInput, predicate->evaluate(nextInput)));
 					}
@@ -1269,7 +1269,7 @@ ACTOR static Future<Void> findAndModify(PlanCheckpoint* outerCheckpoint,
                                         bool projectNew,
                                         PromiseStream<Reference<ScanReturnedContext>> output) {
 	if (!dtr)
-		dtr = NonIsolatedPlan::newTransaction(database);	
+		dtr = NonIsolatedPlan::newTransaction(database);
 	state Reference<PlanCheckpoint> innerCheckpoint(new PlanCheckpoint);
 	state int nTransactions = 1;
 	state FlowLock* outerLock = outerCheckpoint->getDocumentFinishedLock();
@@ -1449,8 +1449,8 @@ ACTOR static Future<Void> projectAndUpdate(PlanCheckpoint* checkpoint,
 			firstDoc = ref(new ScanReturnedContext(inserted, -1, FDB::Key()));
 		}
 
-		if (any || upsertOp) {			
-			wait(firstDoc->commitChanges());			
+		if (any || upsertOp) {
+			wait(firstDoc->commitChanges());
 		}
 
 		if (projectNew && (any || upsertOp)) {

--- a/src/QLPlan.actor.h
+++ b/src/QLPlan.actor.h
@@ -706,8 +706,13 @@ ACTOR Future<std::pair<int64_t, Reference<ScanReturnedContext>>> executeUntilCom
     Reference<DocTransaction> tr);
 
 Reference<Plan> deletePlan(Reference<Plan> subPlan, Reference<UnboundCollectionContext> cx, int64_t limit);
-Reference<Plan> oplogDeletePlan(Reference<Plan> subPlan, Reference<MetadataManager> mm, Namespace ns);
 Reference<Plan> oplogInsertPlan(Reference<Plan> subPlan, std::list<bson::BSONObj>* docs, Reference<MetadataManager> mm, Namespace ns);
 Reference<Plan> flushChanges(Reference<Plan> subPlan);
+
+void gatherObjectsInfo(
+	const DataValue *dv, 
+	std::map<std::string, std::pair<bson::BSONObj, bson::BSONObj>> *updates,
+	std::vector<bson::BSONObj> *inserts,
+	bool isSource);
 
 #endif /* _QL_PLAN_ACTOR_H_ */

--- a/src/QLPlan.actor.h
+++ b/src/QLPlan.actor.h
@@ -518,6 +518,7 @@ struct FindAndModifyPlan : ConcretePlan<FindAndModifyPlan> {
 	Reference<UnboundCollectionContext> cx;
 	Reference<FDB::Database> database;
 	Reference<MetadataManager> mm;
+	Reference<IOplogInserter> oplogInserter;
 
 	FindAndModifyPlan(Reference<Plan> subPlan,
 	                  Reference<IUpdateOp> updateOp,
@@ -526,6 +527,7 @@ struct FindAndModifyPlan : ConcretePlan<FindAndModifyPlan> {
 	                  Optional<bson::BSONObj> ordering,
 	                  bool projectNew,
 	                  Reference<UnboundCollectionContext> cx,
+					  Reference<IOplogInserter> oplogInserter,
 	                  Reference<FDB::Database> database,
 	                  Reference<MetadataManager> mm)
 	    : subPlan(subPlan),
@@ -535,6 +537,7 @@ struct FindAndModifyPlan : ConcretePlan<FindAndModifyPlan> {
 	      projectNew(projectNew),
 	      ordering(ordering),
 	      cx(cx),
+		  oplogInserter(oplogInserter),
 	      database(database),
 	      mm(mm) {}
 

--- a/src/QLPlan.actor.h
+++ b/src/QLPlan.actor.h
@@ -181,31 +181,6 @@ struct ConcretePlan : Plan, ReferenceCounted<PlanType>, FastAllocated<PlanType> 
 	void delref() override { ReferenceCounted<PlanType>::delref(); }
 };
 
-struct OplogUpdatePlan: ConcretePlan<OplogUpdatePlan> {
-	Reference<Plan> subPlan;
-
-	OplogUpdatePlan(Reference<Plan> subPlan, Reference<MetadataManager> mm) : subPlan(subPlan), mm(mm) {
-		ns = Namespace(DocLayerConstants::OPLOG_DB, DocLayerConstants::OPLOG_COL);
-	}
-
-	bson::BSONObj describe() override {
-		return BSON(
-		     // clang-format off
-			"type" << "update oplog"
-		    // clang-format on
-		);
-	}
-
-	PlanType getType() override { return PlanType::Update; }
-
-	FutureStream<Reference<ScanReturnedContext>> execute(PlanCheckpoint* checkpoint,
-	                                                     Reference<DocTransaction> tr) override;														 
-
-	private:
-		Reference<MetadataManager> mm;
-		Namespace ns;
-};
-
 struct TableScanPlan : ConcretePlan<TableScanPlan> {
 	explicit TableScanPlan(Reference<UnboundCollectionContext> cx) : cx(cx) {}
 	bson::BSONObj describe() override {
@@ -731,7 +706,8 @@ ACTOR Future<std::pair<int64_t, Reference<ScanReturnedContext>>> executeUntilCom
     Reference<DocTransaction> tr);
 
 Reference<Plan> deletePlan(Reference<Plan> subPlan, Reference<UnboundCollectionContext> cx, int64_t limit);
-Reference<Plan> oplogDeletePlan(Reference<Plan> subPlan, Reference<MetadataManager> mm);
+Reference<Plan> oplogDeletePlan(Reference<Plan> subPlan, Reference<MetadataManager> mm, Namespace ns);
+Reference<Plan> oplogInsertPlan(Reference<Plan> subPlan, std::list<bson::BSONObj>* docs, Reference<MetadataManager> mm, Namespace ns);
 Reference<Plan> flushChanges(Reference<Plan> subPlan);
 
 #endif /* _QL_PLAN_ACTOR_H_ */

--- a/src/QLPredicate.actor.cpp
+++ b/src/QLPredicate.actor.cpp
@@ -123,7 +123,7 @@ Reference<IPredicate> AndPredicate::simplify() {
 	}
 
 	// AND of one term is just that term
-	if (combine.other.size() == 1) {		
+	if (combine.other.size() == 1) {
 		return combine.other[0];
 	}
 

--- a/src/QLPredicate.actor.cpp
+++ b/src/QLPredicate.actor.cpp
@@ -123,7 +123,7 @@ Reference<IPredicate> AndPredicate::simplify() {
 	}
 
 	// AND of one term is just that term
-	if (combine.other.size() == 1) {
+	if (combine.other.size() == 1) {		
 		return combine.other[0];
 	}
 
@@ -265,7 +265,7 @@ std::string ArraySizePredicate::toString() {
 	return format("ARRAY_SIZE(%d)", size);
 }
 
-Future<bool> EqPredicate::evaluate(Reference<IReadContext> const& context) {
+Future<bool> EqPredicate::evaluate(Reference<IReadContext> const& context) {	
 	DataValue v = value;
 	Future<DataValue> fdv = getMaybeRecursive(context, StringRef());
 	return map(fdv, [v](DataValue dv) { return dv.compare(v) == 0; });
@@ -363,7 +363,7 @@ std::string RangePredicate::toString() {
 	return s;
 }
 
-void RangePredicate::get_range(Optional<DataValue>& min, Optional<DataValue>& max) {
+void RangePredicate::get_range(Optional<DataValue>& min, Optional<DataValue>& max) {	
 	min = min_value;
 	max = max_value;
 }

--- a/src/QLPredicate.actor.cpp
+++ b/src/QLPredicate.actor.cpp
@@ -265,7 +265,7 @@ std::string ArraySizePredicate::toString() {
 	return format("ARRAY_SIZE(%d)", size);
 }
 
-Future<bool> EqPredicate::evaluate(Reference<IReadContext> const& context) {	
+Future<bool> EqPredicate::evaluate(Reference<IReadContext> const& context) {
 	DataValue v = value;
 	Future<DataValue> fdv = getMaybeRecursive(context, StringRef());
 	return map(fdv, [v](DataValue dv) { return dv.compare(v) == 0; });
@@ -363,7 +363,7 @@ std::string RangePredicate::toString() {
 	return s;
 }
 
-void RangePredicate::get_range(Optional<DataValue>& min, Optional<DataValue>& max) {	
+void RangePredicate::get_range(Optional<DataValue>& min, Optional<DataValue>& max) {
 	min = min_value;
 	max = max_value;
 }


### PR DESCRIPTION
### Feauters:
1. Oplog simulation
2. Changes stream server

### Using: 
```
fdbdoc -l 127.0.0.1:27016 -nl 127.0.0.1:8081
```
1. "nl" - is address for changes stream server

### Changes stream server
Provides changes to port for listeners which are connected on port over tcp.

Message format is:
1. 8 bytes for body size (LittleEndian Unit64)
2. One byte delimiter
3. Message body (bson object from local.oplog.rs in binary)

### Recomendations:
1. When local.oplog.rs will be created by doc layer, it's good to add index on "ts" field for best performance.

### Known limitations:
1. Writes logs only for "i", "u", "d" operations (no drops and other operations)
2. Oplog structure has one difference from mongodb, that's exclusion "$" sign from field names (because doc layer has some limitations by it)
3. "Capped" collection is simple deletion documents by time (only last 2 days are stored)
4. Performance is decreased by increased transactions number because oplog (~1.8-2x times)